### PR TITLE
곡 정보 반환값에 아티스트 및 썸네일 정보 추가, 곡 별 타입 튜플에서 딕셔너리 형태로 수정

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,3 @@
-```markdown
 # GenieAPI 🎵
 
 **GenieAPI**는 [Genie Music](https://www.genie.co.kr/) 데이터를 쉽게 가져올 수 있는 Python API 라이브러리입니다.
@@ -34,7 +33,6 @@ print(song)
 # 2. 싱크 가사 다운로드
 # 검색 결과에서 첫 번째 곡의 ID(song[0]['id'])를 사용하여 가사를 다운로드합니다.
 genie.get_lyrics(song[0]['id'])
-```
 
 - **APT ROSE:** 검색할 곡 제목  
 - **limit=1:** 가져올 곡의 개수 (기본값: 1)

--- a/README.MD
+++ b/README.MD
@@ -1,27 +1,41 @@
+```markdown
 # GenieAPI 🎵
 
 **GenieAPI**는 [Genie Music](https://www.genie.co.kr/) 데이터를 쉽게 가져올 수 있는 Python API 라이브러리입니다.
 
 ## 주요 기능 ✨
-- 곡 정보 가져오기
-- 싱크 가사 다운로드 하기
+- **곡 정보 가져오기:**  
+  - 검색어를 입력하면 해당 곡의 정보를 가져옵니다.
+  - 반환되는 정보는 **곡 제목 (title)**, **곡 ID (id)**, **아티스트/앨범 정보 (추가 정보)**, **앨범 아트(썸네일) URL** 등을 포함합니다.
+- **싱크 가사 다운로드:**  
+  - 특정 곡의 ID를 사용하여 싱크 가사가 포함된 `.lrc` 파일을 생성합니다.
+  - 생성된 파일은 `result` 폴더에 저장됩니다.
 
 ## 설치 방법 🛠️
 
-    ```bash
-    pip install GenieAPI
-    ```
+```bash
+pip install GenieAPI
+```
 
 ## 사용 방법 💡
 
-    ```python
-    from genieapi import GenieAPI
+```python
+from genieapi import GenieAPI
 
-    genie = GenieAPI()
-    song = genie.search_song("APT ROSE", limit=1)
+# GenieAPI 인스턴스 생성
+genie = GenieAPI()
 
-    genie.get_lyrics(song[0][1])
-    ```
+# 1. 곡 정보 검색
+# "APT ROSE"라는 곡을 검색하여 1개의 결과를 가져옵니다.
+song = genie.search_song("APT ROSE", limit=1)
+# 반환 예시: [{'title': 'APT ROSE', 'id': '12345678', 'artist': 'APT - Debut Album', 'thumbnail': 'https://thumbnail.link/...'}]
+print(song)
 
-- **APT ROSE**: 검색할 곡 제목  
-- **limit=1**: 가져올 곡의 개수 (기본값: 1)
+# 2. 싱크 가사 다운로드
+# 검색 결과에서 첫 번째 곡의 ID(song[0]['id'])를 사용하여 가사를 다운로드합니다.
+genie.get_lyrics(song[0]['id'])
+```
+
+- **APT ROSE:** 검색할 곡 제목  
+- **limit=1:** 가져올 곡의 개수 (기본값: 1)
+```

--- a/README.MD
+++ b/README.MD
@@ -8,19 +8,20 @@
 
 ## 설치 방법 🛠️
 
-```bash
-pip install GenieAPI
-```
+    ```bash
+    pip install GenieAPI
+    ```
 
-# 사용 방법
-```python
-from genieapi import GenieAPI
+## 사용 방법 💡
 
-genie = GenieAPI()
-song = genie.search_song("APT ROSE",limit=1)
+    ```python
+    from genieapi import GenieAPI
 
-genie.get_lyrics(song[0][1])
-```
+    genie = GenieAPI()
+    song = genie.search_song("APT ROSE", limit=1)
 
-- APT ROSE -> 곡 제목
-- limit=1 -> 가져올 곡의 개수 (기본값: 1)
+    genie.get_lyrics(song[0][1])
+    ```
+
+- **APT ROSE**: 검색할 곡 제목  
+- **limit=1**: 가져올 곡의 개수 (기본값: 1)

--- a/genieapi/GenieAPI.py
+++ b/genieapi/GenieAPI.py
@@ -1,19 +1,18 @@
 import os
 import json
 import requests
-from typing import List, Dict, Optional
-from genieapi.Error import GenieScraperError
+from typing import List, Dict, Optional, Tuple
 from bs4 import BeautifulSoup
+from genieapi.Error import GenieScraperError
 
 
 class GenieAPI:
     """지니뮤직 API"""
 
     def __init__(self):
-        self.LYRICS_BASE_URL = "https://dn.genie.co.kr/app/purchase/get_msl.asp?path=a&songid="
         self.SEARCH_BASE_URL = "https://www.genie.co.kr/search/searchAuto"
-        # 앨범정보 관련 URL (썸네일과 발매일 정보를 추출)
-        self.ALBUM_INFO_URL = "https://www.genie.co.kr/detail/albumInfo"
+        self.SONG_INFO_BASE_URL = "https://www.genie.co.kr/detail/songInfo?xgnm="
+        self.LYRICS_BASE_URL = "https://dn.genie.co.kr/app/purchase/get_msl.asp?path=a&songid="
 
     def _get_request_headers(self) -> dict:
         """브라우저를 모방한 요청 헤더 생성."""
@@ -25,131 +24,95 @@ class GenieAPI:
             )
         }
 
-    def _get_thumbnail_url(self, song_id: str) -> Optional[str]:
-        """
-        노래의 썸네일 URL을 가져옵니다.
-        URL 예: {앨범정보 URL}?xgnm={song_id}
-        """
-        try:
-            url = f"{self.ALBUM_INFO_URL}?xgnm={song_id}"
-            response = requests.get(url, headers=self._get_request_headers())
-            response.raise_for_status()
-            soup = BeautifulSoup(response.text, "html.parser")
-            album_img = soup.select_one("div.photo-zone span.cover > img")
-            if album_img and "src" in album_img.attrs:
-                img_url = album_img["src"]
-                if img_url.startswith("//"):
-                    img_url = "https:" + img_url
-                return img_url.replace("/dims/resize/Q_80,0", "")
-        except Exception as e:
-            print(f"[DEBUG] 썸네일 URL 가져오기 실패: {e}")
-        return None
-
-    def _get_release_date(self, song_id: str) -> Optional[str]:
-        """
-        노래의 발매일 정보를 가져옵니다.
-        URL 예: https://www.genie.co.kr/detail/albumInfo?axnm={song_id}
-        CSS Selector: #body-content > div.album-detail-infos > div.info-zone > ul > li:nth-child(5) > span.value
-        """
-        try:
-            url = f"{self.ALBUM_INFO_URL}?axnm={song_id}"
-            response = requests.get(url, headers=self._get_request_headers())
-            response.raise_for_status()
-            soup = BeautifulSoup(response.text, "html.parser")
-            release_elem = soup.select_one(
-                "#body-content > div.album-detail-infos > div.info-zone > ul > li:nth-child(5) > span.value"
-            )
-            if release_elem:
-                return release_elem.text.strip()
-        except Exception as e:
-            print(f"[DEBUG] 발매일 정보 가져오기 실패: {e}")
-        return None
-
-    def search_song(self, song_name: str, limit: int = 1) -> List[Dict[str, str]]:
+    def search_song(self, query: str, limit: int = 4) -> List[Dict[str, str]]:
         """
         지니뮤직에서 노래 검색.
-        
-        입력:
-            song_name (str): 검색할 노래 이름
-            limit (int, optional): 검색 결과 제한 (1~4). 기본값은 1.
-        
-        반환:
+
+        입력값:
+            query (str): 검색할 노래 이름
+            limit (int, optional): 검색 결과 제한. 기본값은 4.
+
+        반환값:
             각 노래 정보를 담은 dictionary 리스트.
-            각 dictionary는 다음 키를 포함:
+            각 dictionary는 다음 키를 포함합니다:
                 - title: 노래 제목
                 - id: 노래 ID
-                - extra: 추가 정보 (예: 아티스트/앨범)
+                - artist: 아티스트 이름
                 - thumbnail: 썸네일 URL
-                - release_date: 발매일 정보
         """
-        if not 1 <= limit <= 4:
-            raise ValueError("limit 값은 1에서 4 사이여야 합니다.")
-
         try:
             response = requests.get(
                 self.SEARCH_BASE_URL,
-                params={"query": song_name},
+                params={"query": query},
                 headers=self._get_request_headers()
             )
             response.raise_for_status()
             data = response.json()
 
-            songs = []
+            results = []
             for song in data.get("song", [])[:limit]:
-                song_id = song.get("id")
-                thumbnail = self._get_thumbnail_url(song_id)
-                release_date = self._get_release_date(song_id)
-                songs.append({
+                song_id = song.get("id", "")
+                artist, _ = self._parse_genie_extra_info(song.get("field1", ""))
+                thumbnail = self._get_album_art_url(song_id)
+                results.append({
                     "title": song.get("word", ""),
                     "id": song_id,
-                    "extra": song.get("field1", ""),
-                    "thumbnail": thumbnail or "",
-                    "release_date": release_date or ""
+                    "artist": artist,
+                    "thumbnail": thumbnail or "없음"
                 })
 
-            return songs
+            return results
 
         except requests.RequestException as e:
             raise GenieScraperError(f"검색 요청 실패: {e}")
-        except (KeyError, IndexError) as e:
+        except (KeyError, IndexError, json.JSONDecodeError) as e:
             raise GenieScraperError(f"예상치 못한 응답 형식: {e}")
 
-    def get_lyrics(self, song_id: str) -> Optional[str]:
-        """
-        주어진 노래 ID의 가사를 조회하여 LRC 파일을 생성합니다.
-        
-        입력:
-            song_id (str): 노래 고유 식별자
-        
-        반환:
-            생성된 LRC 파일 경로 (str) 또는 None
-        """
+    def _parse_genie_extra_info(self, extra_info: str) -> Tuple[str, str]:
+        """추가 정보에서 아티스트와 앨범 분리"""
+        parts = extra_info.split(' - ', 1)
+        artist = parts[0].strip()
+        album = parts[1].strip() if len(parts) > 1 else ""
+        return artist, album
+
+    def _get_album_art_url(self, song_id: str) -> Optional[str]:
+        """지니뮤직에서 앨범 아트 URL 가져오기"""
         try:
-            url = self.LYRICS_BASE_URL + song_id
-            response = requests.get(url, headers=self._get_request_headers())
+            response = requests.get(
+                f"{self.SONG_INFO_BASE_URL}{song_id}",
+                headers=self._get_request_headers()
+            )
             response.raise_for_status()
+            soup = BeautifulSoup(response.text, 'html.parser')
+            album_img = soup.select_one('div.photo-zone span.cover > img')
+            if album_img and 'src' in album_img.attrs:
+                img_url = album_img['src']
+                if img_url.startswith('//'):
+                    img_url = 'https:' + img_url
+                return img_url.replace('/dims/resize/Q_80,0', '')
+        except Exception as e:
+            print(f"[DEBUG] 앨범 아트 URL 가져오기 실패: {e}")
+        return None
 
-            # JSONP 형식의 응답에서 괄호 안의 JSON 문자열 추출
-            text = response.text
-            json_str = text[text.index("(") + 1 : text.rindex(")")]
-            return self._make_lrc_file(song_id, json_str)
-
+    def get_lyrics(self, song_id: str) -> Optional[str]:
+        """주어진 노래 ID의 가사 조회."""
+        try:
+            response = requests.get(
+                f"{self.LYRICS_BASE_URL}{song_id}",
+                headers=self._get_request_headers()
+            )
+            response.raise_for_status()
+            lyrics_json_str = response.text[
+                response.text.index("(") + 1:response.text.rindex(")")
+            ]
+            return self._make_lrc_file(song_id, lyrics_json_str)
         except requests.RequestException as e:
             raise GenieScraperError(f"가사 조회 실패: {e}")
         except (ValueError, json.JSONDecodeError) as e:
             raise GenieScraperError(f"잘못된 가사 형식: {e}")
 
     def _make_lrc_file(self, file_name: str, lyrics_json: str) -> str:
-        """
-        동기화된 가사를 가진 LRC 파일을 생성합니다.
-        
-        입력:
-            file_name (str): 출력 파일의 기본 이름
-            lyrics_json (str): 가사와 타임스탬프를 포함한 JSON 문자열
-        
-        반환:
-            생성된 LRC 파일의 경로 (str)
-        """
+        """동기화된 가사를 가진 LRC 파일 생성."""
         os.makedirs("result", exist_ok=True)
         try:
             lyrics_data = json.loads(lyrics_json)
@@ -157,12 +120,10 @@ class GenieAPI:
             raise GenieScraperError(f"가사 JSON 파싱 실패: {e}")
 
         output_path = os.path.join("result", f"{file_name}.lrc")
-        lrc_lines = []
-        for time_ms, lyric in sorted(lyrics_data.items(), key=lambda x: int(x[0])):
-            minutes = int(time_ms) // 60000
-            seconds = (int(time_ms) % 60000) // 1000
-            centiseconds = (int(time_ms) % 1000) // 10
-            lrc_lines.append(f"[{minutes:02}:{seconds:02}.{centiseconds:02}] {lyric}")
+        lrc_lines = [
+            f"[{int(time_ms) // 60000:02}:{(int(time_ms) % 60000) // 1000:02}.{(int(time_ms) % 1000) // 10:02}] {lyric}"
+            for time_ms, lyric in sorted(lyrics_data.items(), key=lambda x: int(x[0]))
+        ]
 
         with open(output_path, "w", encoding="utf-8") as f:
             f.write("\n".join(lrc_lines))

--- a/genieapi/GenieAPI.py
+++ b/genieapi/GenieAPI.py
@@ -1,9 +1,9 @@
 import os
 import json
 import requests
-from typing import List, Tuple, Optional
+from typing import List, Dict, Optional
 from genieapi.Error import GenieScraperError
-
+from bs4 import BeautifulSoup
 
 
 class GenieAPI:
@@ -12,23 +12,75 @@ class GenieAPI:
     def __init__(self):
         self.LYRICS_BASE_URL = "https://dn.genie.co.kr/app/purchase/get_msl.asp?path=a&songid="
         self.SEARCH_BASE_URL = "https://www.genie.co.kr/search/searchAuto"
+        # 앨범정보 관련 URL (썸네일과 발매일 정보를 추출)
+        self.ALBUM_INFO_URL = "https://www.genie.co.kr/detail/albumInfo"
 
     def _get_request_headers(self) -> dict:
         """브라우저를 모방한 요청 헤더 생성."""
         return {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/91.0.4472.124 Safari/537.36"
+            )
         }
 
-    def search_song(self, song_name: str, limit: int = 1) -> List[Tuple[str, str, str]]:
+    def _get_thumbnail_url(self, song_id: str) -> Optional[str]:
+        """
+        노래의 썸네일 URL을 가져옵니다.
+        URL 예: {앨범정보 URL}?xgnm={song_id}
+        """
+        try:
+            url = f"{self.ALBUM_INFO_URL}?xgnm={song_id}"
+            response = requests.get(url, headers=self._get_request_headers())
+            response.raise_for_status()
+            soup = BeautifulSoup(response.text, "html.parser")
+            album_img = soup.select_one("div.photo-zone span.cover > img")
+            if album_img and "src" in album_img.attrs:
+                img_url = album_img["src"]
+                if img_url.startswith("//"):
+                    img_url = "https:" + img_url
+                return img_url.replace("/dims/resize/Q_80,0", "")
+        except Exception as e:
+            print(f"[DEBUG] 썸네일 URL 가져오기 실패: {e}")
+        return None
+
+    def _get_release_date(self, song_id: str) -> Optional[str]:
+        """
+        노래의 발매일 정보를 가져옵니다.
+        URL 예: https://www.genie.co.kr/detail/albumInfo?axnm={song_id}
+        CSS Selector: #body-content > div.album-detail-infos > div.info-zone > ul > li:nth-child(5) > span.value
+        """
+        try:
+            url = f"{self.ALBUM_INFO_URL}?axnm={song_id}"
+            response = requests.get(url, headers=self._get_request_headers())
+            response.raise_for_status()
+            soup = BeautifulSoup(response.text, "html.parser")
+            release_elem = soup.select_one(
+                "#body-content > div.album-detail-infos > div.info-zone > ul > li:nth-child(5) > span.value"
+            )
+            if release_elem:
+                return release_elem.text.strip()
+        except Exception as e:
+            print(f"[DEBUG] 발매일 정보 가져오기 실패: {e}")
+        return None
+
+    def search_song(self, song_name: str, limit: int = 1) -> List[Dict[str, str]]:
         """
         지니뮤직에서 노래 검색.
-
-        입력값:
+        
+        입력:
             song_name (str): 검색할 노래 이름
-            limit (int, optional): 검색 결과 제한. 기본값은 1.
-
-        반환값:
-            (노래 이름, 노래 ID, 추가 필드)의 튜플 리스트
+            limit (int, optional): 검색 결과 제한 (1~4). 기본값은 1.
+        
+        반환:
+            각 노래 정보를 담은 dictionary 리스트.
+            각 dictionary는 다음 키를 포함:
+                - title: 노래 제목
+                - id: 노래 ID
+                - extra: 추가 정보 (예: 아티스트/앨범)
+                - thumbnail: 썸네일 URL
+                - release_date: 발매일 정보
         """
         if not 1 <= limit <= 4:
             raise ValueError("limit 값은 1에서 4 사이여야 합니다.")
@@ -43,9 +95,17 @@ class GenieAPI:
             data = response.json()
 
             songs = []
-            for i in range(min(limit, len(data.get('song', [])))):
-                song = data['song'][i]
-                songs.append((song['word'], song['id'], song.get('field1', '')))
+            for song in data.get("song", [])[:limit]:
+                song_id = song.get("id")
+                thumbnail = self._get_thumbnail_url(song_id)
+                release_date = self._get_release_date(song_id)
+                songs.append({
+                    "title": song.get("word", ""),
+                    "id": song_id,
+                    "extra": song.get("field1", ""),
+                    "thumbnail": thumbnail or "",
+                    "release_date": release_date or ""
+                })
 
             return songs
 
@@ -56,23 +116,23 @@ class GenieAPI:
 
     def get_lyrics(self, song_id: str) -> Optional[str]:
         """
-        주어진 노래 ID의 가사 조회.
-
-        입력값:
+        주어진 노래 ID의 가사를 조회하여 LRC 파일을 생성합니다.
+        
+        입력:
             song_id (str): 노래 고유 식별자
-
-        반환값:
-            생성된 LRC 파일 경로 또는 None
+        
+        반환:
+            생성된 LRC 파일 경로 (str) 또는 None
         """
         try:
-            response = requests.get(
-                self.LYRICS_BASE_URL + song_id,
-                headers=self._get_request_headers()
-            )
+            url = self.LYRICS_BASE_URL + song_id
+            response = requests.get(url, headers=self._get_request_headers())
             response.raise_for_status()
 
-            lyrics_json_str = response.text[response.text.index("(") + 1:response.text.rindex(")")]
-            return self._make_lrc_file(song_id, lyrics_json_str)
+            # JSONP 형식의 응답에서 괄호 안의 JSON 문자열 추출
+            text = response.text
+            json_str = text[text.index("(") + 1 : text.rindex(")")]
+            return self._make_lrc_file(song_id, json_str)
 
         except requests.RequestException as e:
             raise GenieScraperError(f"가사 조회 실패: {e}")
@@ -81,26 +141,30 @@ class GenieAPI:
 
     def _make_lrc_file(self, file_name: str, lyrics_json: str) -> str:
         """
-        동기화된 가사를 가진 LRC 파일 생성.
-
-        입력값:
-            file_name (str): 출력 파일 기본 이름
+        동기화된 가사를 가진 LRC 파일을 생성합니다.
+        
+        입력:
+            file_name (str): 출력 파일의 기본 이름
             lyrics_json (str): 가사와 타임스탬프를 포함한 JSON 문자열
-
-        반환값:
-            생성된 LRC 파일 경로
+        
+        반환:
+            생성된 LRC 파일의 경로 (str)
         """
         os.makedirs("result", exist_ok=True)
+        try:
+            lyrics_data = json.loads(lyrics_json)
+        except json.JSONDecodeError as e:
+            raise GenieScraperError(f"가사 JSON 파싱 실패: {e}")
 
-        lyrics_data = json.loads(lyrics_json)
         output_path = os.path.join("result", f"{file_name}.lrc")
+        lrc_lines = []
+        for time_ms, lyric in sorted(lyrics_data.items(), key=lambda x: int(x[0])):
+            minutes = int(time_ms) // 60000
+            seconds = (int(time_ms) % 60000) // 1000
+            centiseconds = (int(time_ms) % 1000) // 10
+            lrc_lines.append(f"[{minutes:02}:{seconds:02}.{centiseconds:02}] {lyric}")
 
         with open(output_path, "w", encoding="utf-8") as f:
-            # 타임스탬프 정렬 및 LRC 형식화
-            lrc_lines = [
-                f"[{int(time_ms) // 60000:02}:{(int(time_ms) % 60000) // 1000:02}.{(int(time_ms) % 1000) // 10:02}] {lyric}"
-                for time_ms, lyric in sorted(lyrics_data.items(), key=lambda x: int(x[0]))
-            ]
             f.write("\n".join(lrc_lines))
         print(f"[GENIEAPI] LRC 파일 생성: {output_path}")
         return output_path


### PR DESCRIPTION
- search_song 함수의 반환값을 튜플에서 딕셔너리로 변경하여, 곡 제목, ID, 아티스트, 썸네일 URL을 포함하도록 수정했습니다.
- 튜플에서 딕셔너리로 바꾼 이유는 사용자들이 곡 정보를 더 명확하게 확인할 수 있게 하려는 의도가 있었습니다..
- 기존 기능과의 호환성을 유지하면서, 코드 가독성 및 예외 처리를 개선했습니다.
- 그에 맞게 readme.md의 내용도 보완했습니다.